### PR TITLE
Creating converter datetime to unix timestamp based in miliseconds

### DIFF
--- a/DevUtils.test/DevUtils.test/DateTimeExtensions/DateExtensions.cs
+++ b/DevUtils.test/DevUtils.test/DateTimeExtensions/DateExtensions.cs
@@ -161,10 +161,10 @@ namespace DevUtils.test.DateTimeExtensions
 
         #region ToUnixTimestamp
         /// <summary>
-        /// Test method ToUnixTimestamp and overloads
+        /// Test method ToUnixTimestamp and overloads based in secods
         /// </summary>
         [TestMethod]
-        public void ToUnixTimestampAndOverloads()
+        public void ToUnixTimestampAndOverloadsBasedInSeconds()
         {
             var unix1 = (UtcDate - new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc)).TotalSeconds.TryParseLong();
             var unix2 = (LocalDate.ToUtc(LocalTimeZoneInfo) - new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc)).TotalSeconds.TryParseLong();
@@ -177,6 +177,25 @@ namespace DevUtils.test.DateTimeExtensions
             Assert.AreEqual(unix2, LocalDate.ToUnixTimestamp(UtcTimeZoneInfo));
             Assert.AreEqual(unix2, LocalDate.ToUnixTimestamp(UtcTimeZoneName));
         }
+
+        /// <summary>
+        /// Test method ToUnixTimestamp and overloads based in milisecods
+        /// </summary>
+        [TestMethod]
+        public void ToUnixTimestampAndOverloadsBasedInMiliseconds()
+        {
+            var unix1 = (UtcDate - new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc)).TotalMilliseconds.TryParseLong();
+            var unix2 = (LocalDate.ToUtc(LocalTimeZoneInfo) - new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc)).TotalMilliseconds.TryParseLong();
+
+            Assert.AreEqual(unix1, UtcDate.ToUnixTimestampMilisecondsBased());
+            Assert.AreEqual(unix1, UtcDate.ToUnixTimestampMilisecondsBased(UtcTimeZoneInfo));
+            Assert.AreEqual(unix1, UtcDate.ToUnixTimestampMilisecondsBased(UtcTimeZoneName));
+
+            Assert.AreEqual(unix2, LocalDate.ToUnixTimestampMilisecondsBased());
+            Assert.AreEqual(unix2, LocalDate.ToUnixTimestampMilisecondsBased(UtcTimeZoneInfo));
+            Assert.AreEqual(unix2, LocalDate.ToUnixTimestampMilisecondsBased(UtcTimeZoneName));
+        }
+
         #endregion
 
         #region FromUnixTimestamp

--- a/DevUtils/DevUtils/DateTimeExtensions/DateExtensions.cs
+++ b/DevUtils/DevUtils/DateTimeExtensions/DateExtensions.cs
@@ -192,7 +192,7 @@ namespace DevUtils.DateTimeExtensions
 
         #region ToUnixTimestamp
         /// <summary>
-        /// Convert date to unix timestamp
+        /// Convert date to unix timestamp based in secods
         /// </summary>
         /// <param name="date">date to convert</param>
         /// <param name="timezoneInfo">current date timezone info</param>
@@ -211,7 +211,7 @@ namespace DevUtils.DateTimeExtensions
         }
 
         /// <summary>
-        /// Convert date to unix timestamp
+        /// Convert date to unix timestamp based in secods
         /// </summary>
         /// <param name="date">date to convert</param>
         /// <param name="timezoneName">current date timezone name</param>
@@ -223,7 +223,7 @@ namespace DevUtils.DateTimeExtensions
         }
 
         /// <summary>
-        /// Convert date to unix timestamp
+        /// Convert date to unix timestamp based in secods
         /// </summary>
         /// <param name="date">date to convert</param>
         /// <returns>unix timestamp</returns>
@@ -232,6 +232,49 @@ namespace DevUtils.DateTimeExtensions
             var timezoneInfo = BaseDateTimeExtensions.GetDefaultTimezoneInfo();
             return date.ToUnixTimestamp(timezoneInfo);
         }
+
+        /// <summary>
+        /// Convert date to unix timestamp based in milisecods
+        /// </summary>
+        /// <param name="date">date to convert</param>
+        /// <param name="timezoneInfo">current date timezone info</param>
+        /// <returns>unix timestamp</returns>
+        public static long ToUnixTimestampMilisecondsBased(this DateTime date, TimeZoneInfo timezoneInfo)
+        {
+            try
+            {
+                return (date.ToUtc(timezoneInfo) - new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc)).TotalMilliseconds.TryParseLong();
+            }
+            catch (Exception e)
+            {
+                Debug.WriteLine(e);
+                return 0;
+            }
+        }
+
+        /// <summary>
+        /// Convert date to unix timestamp based in milisecods
+        /// </summary>
+        /// <param name="date">date to convert</param>
+        /// <param name="timezoneName">current date timezone name</param>
+        /// <returns>unix timestamp</returns>
+        public static long ToUnixTimestampMilisecondsBased(this DateTime date, string timezoneName)
+        {
+            var timezoneInfo = BaseDateTimeExtensions.GetTimezoneInfo(timezoneName);
+            return date.ToUnixTimestampMilisecondsBased(timezoneInfo);
+        }
+
+        /// <summary>
+        /// Convert date to unix timestamp based in milisecods
+        /// </summary>
+        /// <param name="date">date to convert</param>
+        /// <returns>unix timestamp</returns>
+        public static long ToUnixTimestampMilisecondsBased(this DateTime date)
+        {
+            var timezoneInfo = BaseDateTimeExtensions.GetDefaultTimezoneInfo();
+            return date.ToUnixTimestampMilisecondsBased(timezoneInfo);
+        }
+
         #endregion
 
         #region FromUnixTimestamp


### PR DESCRIPTION
Adicionado um método para converter Datetime em timestamp, baseando no total de milisegundos desde a data de 01/01/1970.